### PR TITLE
Session Support via Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@
 
 > chdb-server queries default to stateless. Stateful sessions can be generated with Basic HTTP Auth.
 
+![image](https://github.com/chdb-io/chdb-server/assets/1423657/dee938a2-ec2a-4b4a-87a9-458a6db791a0)
 
-### [Public Demo](https://chdb.fly.dev/)
+
+
+### [Play with Public Demo](https://chdb.fly.dev/)
 
 
 <br>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 # chdb-server
 [chDB](https://github.com/auxten/chdb) + basic API server in a docker container, for fast testing and feature validation.
 
+> chdb-server queries default to stateless. Stateful sessions can be generated with Basic HTTP Auth.
+
+
 ### [Public Demo](https://chdb.fly.dev/)
 
 
@@ -17,6 +20,7 @@
 </a>
 
 <br><br>
+
 
 ### Docker Demo
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
+flask_httpauth
 chdb


### PR DESCRIPTION
This PR adds chdb stateful session support when Basic HTTP Auth is provided.
The auth is not actually checked, but simply converted to a hash used as a temporary storage path.
The path for storage can be controlled through the `DATA` env variable and defaults to `.chdb_data'

![image](https://github.com/chdb-io/chdb-server/assets/1423657/59fb78c0-80ae-4564-bd1c-c9ba6af2dcf2)
